### PR TITLE
Added RANDR extension in xvfb

### DIFF
--- a/entry_point.sh
+++ b/entry_point.sh
@@ -11,7 +11,7 @@ function shutdown {
 export DISPLAY=:0
 
 sudo -E -i -u seluser \
-  Xvfb $DISPLAY -screen 0 $GEOMETRY &
+  Xvfb $DISPLAY -screen 0 $GEOMETRY +extension RANDR &
 NODE_PID=$!
 
 #trap shutdown SIGTERM SIGINT


### PR DESCRIPTION
Received Xlib:  extension "RANDR" missing on display error when trying to run chrome. After adding this extension it runs when logged in via VNC.